### PR TITLE
install into 'site'

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,8 @@ if ($Config{gccversion}) {
 WriteMakefile(
     NAME            => 'autobox',
     VERSION_FROM    => 'lib/autobox.pm',
-    INSTALLDIRS     => 'perl',
+    INSTALLDIRS     => ($] >= 5.014 ? 'site' : 'perl'),
+    #compatibility in case module was installed into lib earlier
     PREREQ_PM       => {
         'Scope::Guard'   => '0.20',
     },


### PR DESCRIPTION
Only from Perl version 5.14, for compatibility in case module was installed into lib earlier. In Perls from 5.12, 'site' is earlier in @INC, so if it was installed into 'lib' earlier, it would not matter. But I choosed 5.14, because some Unix distribution could modify that order in 5.12 and 5.14 is not included into Unix dists yet.
