### PR TITLE
allow for other debugger output when checking for expected string

### DIFF
--- a/t/debugger.t
+++ b/t/debugger.t
@@ -12,4 +12,4 @@ use Test::More tests => 1;
 $ENV{PERLDB_OPTS} = 'NonStop=1';
 
 chomp(my $got = capturex($^X, '-d', "$Bin/debugger.pl"));
-is $got, 'foo -> bar -> baz -> quux', 'runs under perl -d';
+isnt index($got, 'foo -> bar -> baz -> quux'), -1, 'runs under perl -d';


### PR DESCRIPTION
debugger.t expects a particular string to be output when test code is run under the debugger. It assumes that that will be the only output.

However, the user's .perldb file may generate output, contaminating the output and thus invalidating the test.

Instead, look for the presence of the expected string in the output, ignoring everything else.